### PR TITLE
`main` is deprecated in Gradle 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ dependencies {
 task requireJavadoc(type: JavaExec) {
   group = 'Documentation'
   description = 'Ensures that Javadoc documentation exists.'
-  main = "org.plumelib.javadoc.RequireJavadoc"
+  mainClass = "org.plumelib.javadoc.RequireJavadoc"
   classpath = configurations.requireJavadoc
   args "src/main/java"
 }


### PR DESCRIPTION
`mainClass` was add in Gradle 6.8, so this change only won't work with earlier versions.