### PR TITLE
Add dependsOn jar to requireJavadoc task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,9 +138,9 @@ dependencies {
   requireJavadoc "org.plumelib:require-javadoc:1.0.4"
 }
 task requireJavadoc(type: JavaExec) {
-  # "dependsOn jar" because this is the requireJavadoc project, and Gradle uses
-  # the built-from-source version of 'org.plumelib:require-javadoc'.  So declare
-  # a dependency on it.
+  // "dependsOn jar" because this is the requireJavadoc project, and Gradle uses
+  // the built-from-source version of 'org.plumelib:require-javadoc'.  So declare
+  // a dependency on it.
   dependsOn jar
   description = 'Ensures that Javadoc documentation exists.'
   mainClass = "org.plumelib.javadoc.RequireJavadoc"

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ dependencies {
   requireJavadoc "org.plumelib:require-javadoc:1.0.4"
 }
 task requireJavadoc(type: JavaExec) {
+  dependsOn jar
   description = 'Ensures that Javadoc documentation exists.'
   mainClass = "org.plumelib.javadoc.RequireJavadoc"
   classpath = configurations.requireJavadoc

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,9 @@ dependencies {
   requireJavadoc "org.plumelib:require-javadoc:1.0.4"
 }
 task requireJavadoc(type: JavaExec) {
+  # "dependsOn jar" because this is the requireJavadoc project, and Gradle uses
+  # the built-from-source version of 'org.plumelib:require-javadoc'.  So declare
+  # a dependency on it.
   dependsOn jar
   description = 'Ensures that Javadoc documentation exists.'
   mainClass = "org.plumelib.javadoc.RequireJavadoc"


### PR DESCRIPTION
Because this is the requireJavadoc project, Gradle uses the built from source version of 'org.plumelib:require-javadoc:1.0.4'.  So, the requireJavadoc task has to declare a dependency on it.