### PR TITLE
Run Spotless under Java 21, in its own CI job

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,6 +3,28 @@ name: Java CI with Gradle
 "on": [push, pull_request]
 
 jobs:
+
+  # Formatting does not depend on the Java version, so Spotless runs in this single job rather than
+  # in every job of the "build" matrix below.
+  spotless:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          show-progress: false
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          check-latest: true
+          cache: 'gradle'
+      - name: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck --stacktrace
+
   build:
 
     runs-on: ubuntu-latest
@@ -20,14 +42,26 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.java }}
+          # "setup-java" makes the last version listed the default JAVA_HOME, so Gradle itself runs
+          # under Java 21 no matter which version this job tests.  Java 17 is the toolchain that
+          # build.gradle.kts compiles with; listing it saves Gradle from downloading a JDK.  A version
+          # that the list names twice is tolerated by "setup-java".
+          java-version: |
+            ${{ matrix.java }}
+            17
+            21
           check-latest: true
           cache: 'gradle'
-      - name: java -version
-        run: java -version
-      - name: Warm up Gradle cache
-        run: ./gradlew spotlessCheck > /dev/null 2>&1 || (sleep 60 && true)
+      - name: Show the Java versions
+        run: |
+          echo 'JVM that runs Gradle:'
+          java -version
+          echo 'JVM that runs the tests:'
+          "$JAVA_HOME_${{ matrix.java }}_${{ runner.arch }}/bin/java" -version
+      # Gradle does not auto-detect the JDKs that "setup-java" installs, because
+      # they are in the tool cache rather than in a standard location.
+      # The "spotless" job above performs the formatting checks.
+      # "build" runs "check", which runs both the JUnit tests and the "runShellTests" task,
+      # so src/test/run-tests.sh needs no step of its own.
       - name: ./gradlew build
-        run: ./gradlew build
-      - name: run-tests.sh
-        run: src/test/run-tests.sh
+        run: ./gradlew build -x spotlessCheck -PtestJavaVersion=${{ matrix.java }} -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_${{ matrix.java }}_${{ runner.arch }},JAVA_HOME_17_${{ runner.arch }},JAVA_HOME_21_${{ runner.arch }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,27 +4,6 @@ name: Java CI with Gradle
 
 jobs:
 
-  # Formatting does not depend on the Java version, so Spotless runs in this single job rather than
-  # in every job of the "build" matrix below.
-  spotless:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-          show-progress: false
-      - name: Set up JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          check-latest: true
-          cache: 'gradle'
-      - name: ./gradlew spotlessCheck
-        run: ./gradlew spotlessCheck --stacktrace
-
   build:
 
     runs-on: ubuntu-latest
@@ -43,9 +22,10 @@ jobs:
         with:
           distribution: 'temurin'
           # "setup-java" makes the last version listed the default JAVA_HOME, so Gradle itself runs
-          # under Java 21 no matter which version this job tests.  Java 17 is the toolchain that
-          # build.gradle.kts compiles with; listing it saves Gradle from downloading a JDK.  A version
-          # that the list names twice is tolerated by "setup-java".
+          # under Java 21 no matter which version this job tests.  Spotless runs within the Gradle
+          # JVM, and google-java-format is compiled for Java 21, so Java 21 is the minimum.  Java 17
+          # is the toolchain that build.gradle.kts compiles with; listing it saves Gradle from
+          # downloading a JDK.  A version that the list names twice is tolerated by "setup-java".
           java-version: |
             ${{ matrix.java }}
             17
@@ -60,8 +40,7 @@ jobs:
           "$JAVA_HOME_${{ matrix.java }}_${{ runner.arch }}/bin/java" -version
       # Gradle does not auto-detect the JDKs that "setup-java" installs, because
       # they are in the tool cache rather than in a standard location.
-      # The "spotless" job above performs the formatting checks.
-      # "build" runs "check", which runs both the JUnit tests and the "runShellTests" task,
-      # so src/test/run-tests.sh needs no step of its own.
+      # "build" runs "check", which runs the JUnit tests, the "runShellTests" task, and
+      # "spotlessCheck", so neither src/test/run-tests.sh nor Spotless needs a step of its own.
       - name: ./gradlew build
-        run: ./gradlew build -x spotlessCheck -PtestJavaVersion=${{ matrix.java }} -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_${{ matrix.java }}_${{ runner.arch }},JAVA_HOME_17_${{ runner.arch }},JAVA_HOME_21_${{ runner.arch }}
+        run: ./gradlew build -PtestJavaVersion=${{ matrix.java }} -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_${{ matrix.java }}_${{ runner.arch }},JAVA_HOME_17_${{ runner.arch }},JAVA_HOME_21_${{ runner.arch }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,6 +162,17 @@ tasks.register<Exec>("runShellTests") {
   description = "Run the tests in src/test/run-tests.sh."
   // The script runs the fat jar, which "shadowJar" builds.
   dependsOn("shadowJar")
+  // Name the JVM that the script runs the fat jar under, so that `-PtestJavaVersion` selects the
+  // JVM for these tests as it does for the JUnit tests.  Naming the JVM rather than putting it on
+  // the script's PATH leaves the script's nested `./gradlew` invocation running under the JVM that
+  // Gradle itself runs under; that JVM is the one known to support this build's Gradle version.
+  val shellTestJavaHome: Provider<String> =
+    javaToolchains
+      .launcherFor { languageVersion = testJavaVersion }
+      .map { it.metadata.installationPath.asFile.absolutePath }
+  // Set the environment in `doFirst`, so that merely configuring this task does not provision a
+  // JDK.
+  doFirst { environment("REQUIRE_JAVADOC_JAVA_HOME", shellTestJavaHome.get()) }
   commandLine("./src/test/run-tests.sh")
   // The JUnit tests' failures are more informative than the shell tests' failures.
   mustRunAfter(tasks.named("test"))

--- a/src/test/run-tests.sh
+++ b/src/test/run-tests.sh
@@ -9,7 +9,16 @@ cd "${SCRIPT_DIR}" || exit 1
 (cd ../.. && ./gradlew -q assemble)
 sleep .1
 
-cmd_base="java \
+# The Gradle task "runShellTests" sets REQUIRE_JAVADOC_JAVA_HOME to the JVM that
+# `-PtestJavaVersion` names, so that these tests run under the same JVM as the JUnit tests.
+# When the variable is unset, as when a developer runs this script directly, use the PATH's `java`.
+if [ -n "${REQUIRE_JAVADOC_JAVA_HOME}" ]; then
+  java_cmd="${REQUIRE_JAVADOC_JAVA_HOME}/bin/java"
+else
+  java_cmd="java"
+fi
+
+cmd_base="${java_cmd} \
   --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
@@ -29,7 +38,7 @@ ${cmd} > out.txt || true
 cd -
 diff -u tests11/expected.txt tests11/out.txt
 
-JAVA_VER=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//') \
+JAVA_VER=$(${java_cmd} -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//') \
   && if [ "$JAVA_VER" -ge 16 ]; then
     cd tests17
     ${cmd} > out.txt || true


### PR DESCRIPTION
google-java-format 1.36.1 is compiled for Java 21, so Spotless failed in the "build (17)" job, which ran Gradle itself under Java 17.

Adopt the workflow that build.gradle.kts already describes, and that bcel-util, javac-parse, merging, and plume-util already use:  run Spotless in a single job under Java 21, and run Gradle under Java 21 in every job of the "build" matrix, selecting the test JVM with -PtestJavaVersion.

The shell tests run the fat jar under `java`, so with Gradle always under Java 21 they would no longer exercise the matrix JDK.  Pass them the JVM that -PtestJavaVersion names, as the "merging" project does for its Makefile tests. Naming the JVM rather than putting it on the script's PATH leaves the script's nested `./gradlew` invocation under the JVM that Gradle itself runs under.

"build" runs "check", which runs "runShellTests", so drop the workflow's separate step for src/test/run-tests.sh.